### PR TITLE
update to use new w3ui APIs

### DIFF
--- a/components/Authenticator.js
+++ b/components/Authenticator.js
@@ -1,79 +1,58 @@
-import { useState } from "react";
-import { useAuth, AuthStatus } from "@w3ui/react-keyring";
+import React, { useState } from 'react'
+import { useKeyring } from '@w3ui/react-keyring'
 
-export default function Authenticator({ children }) {
-  const {
-    authStatus,
-    identity,
-    registerAndStoreIdentity,
-    cancelRegisterAndStoreIdentity,
-  } = useAuth();
-  const [email, setEmail] = useState("");
+export default function Authenticator ({ children }) {
+  const [{ space }, { createSpace, registerSpace, cancelRegisterSpace }] = useKeyring()
+  const [email, setEmail] = useState('')
+  const [submitted, setSubmitted] = useState(false)
 
-  if (authStatus === AuthStatus.SignedIn) {
-    return children;
+  if (space?.registered()) {
+    return children
   }
 
-  if (authStatus === AuthStatus.EmailVerification) {
+  if (submitted) {
     return (
       <div>
-        <h1 className="near-white">Verify your email address!</h1>
-        <p>
-          Click the link in the email we sent to {identity && identity.email} to
-          sign in.
-        </p>
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            cancelRegisterAndStoreIdentity();
-          }}
-        >
-          <button type="submit" className="ph3 pv2">
-            Cancel
-          </button>
+        <h1 className='near-white'>Verify your email address!</h1>
+        <p>Click the link in the email we sent to {email} to sign in.</p>
+        <form onSubmit={e => { e.preventDefault(); cancelRegisterSpace() }}>
+          <button type='submit' className='ph3 pv2'>Cancel</button>
         </form>
       </div>
-    );
+    )
   }
 
-  const handleRegisterSubmit = async (e) => {
-    e.preventDefault();
+  const handleRegisterSubmit = async e => {
+    e.preventDefault()
+    setSubmitted(true)
     try {
-      await registerAndStoreIdentity(email);
+      await createSpace()
+      await registerSpace(email)
     } catch (err) {
-      throw new Error("failed to register", { cause: err });
+      throw new Error('failed to register', { cause: err })
+    } finally {
+      setSubmitted(false)
     }
-  };
+  }
 
   return (
     <form onSubmit={handleRegisterSubmit}>
-      <div className="mb3">
-        <label htmlFor="email" className="db mb2">
-          Email address:
-        </label>
-        <input
-          id="email"
-          className="db pa2 w-100"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          required
-        />
+      <div className='mb3'>
+        <label htmlFor='email' className='db mb2'>Email address:</label>
+        <input id='email' className='db pa2 w-100' type='email' value={email} onChange={e => setEmail(e.target.value)} required />
       </div>
-      <button type="submit" className="ph3 pv2">
-        Register
-      </button>
+      <button type='submit' className='ph3 pv2' disabled={submitted}>Register</button>
     </form>
-  );
+  )
 }
 
 /**
  * Wrapping a component with this HoC ensures an identity exists.
  */
-export function withIdentity(Component) {
-  return (props) => (
+export function withIdentity (Component) {
+  return props => (
     <Authenticator>
       <Component {...props} />
     </Authenticator>
-  );
+  )
 }

--- a/components/ImageListItem.js
+++ b/components/ImageListItem.js
@@ -1,4 +1,5 @@
 export default function ImageListItem({ cid, data }) {
+  cid = cid.toString()
   if (/bagb/.test(`${cid}`)) {
     return <li key={cid}>CAR cid: {cid}</li>;
   }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@w3ui/react-keyring": "^1.0.1",
-    "@w3ui/react-uploader": "^2.1.2",
-    "@w3ui/react-uploads-list": "^1.1.2",
+    "@w3ui/react-keyring": "^2.0.1",
+    "@w3ui/react-uploader": "^3.0.1",
+    "@w3ui/react-uploads-list": "^2.0.1",
     "next": "13.0.1",
     "react": "18.2.0",
     "react-camera-pro": "^1.2.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,40 +1,39 @@
-import { useEffect } from "react";
-import { AuthProvider, useAuth } from "@w3ui/react-keyring";
-import { UploaderProvider } from "@w3ui/react-uploader";
+import React, { useEffect } from 'react'
+import { KeyringProvider, useKeyring } from '@w3ui/react-keyring'
+import { UploaderProvider } from '@w3ui/react-uploader'
 import { UploadsListProvider } from "@w3ui/react-uploads-list";
 
-import "../styles/globals.css";
-import "../styles/tachyons.min.css";
-import "../styles/spinner.css";
+import '../styles/globals.css'
+import '../styles/spinner.css'
+import '../styles/tachyons.min.css'
 
-function App({ Component, pageProps }) {
+function App ({ Component, pageProps }) {
   return (
-    <AuthProvider>
+    <KeyringProvider>
       <UploaderProvider>
         <UploadsListProvider>
-          <IdentityLoader>
-            <div className="vh-100 pt5 flex flex-column justify-center items-center sans-serif light-silver">
+          <AgentLoader>
+            <div className='vh-100 flex flex-column justify-center items-center sans-serif light-silver pt5'>
               <header>
-                <img src="/logo.png" width="250" alt="logo" />
+                <img src='/logo.png' width='250' alt='logo' />
               </header>
-              <div className="w-90 w-50-ns mw6 h-100">
+              <div className='w-90 w-50-ns mw6 h-100'>
                 <Component {...pageProps} />
               </div>
             </div>
-          </IdentityLoader>
+          </AgentLoader>
         </UploadsListProvider>
       </UploaderProvider>
-    </AuthProvider>
-  );
+    </KeyringProvider>
+  )
 }
 
-function IdentityLoader({ children }) {
-  const { loadDefaultIdentity } = useAuth();
+
+function AgentLoader ({ children }) {
+  const [, { loadAgent }] = useKeyring()
   // eslint-disable-next-line
-  useEffect(() => {
-    loadDefaultIdentity();
-  }, []); // try to load default identity - once.
-  return children;
+  useEffect(() => { loadAgent() }, []) // load agent - once.
+  return children
 }
 
 export default App;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,9 +1,10 @@
-import { useState, useRef } from "react";
-import { withIdentity } from "../components/Authenticator";
 import { Camera } from "react-camera-pro";
-import { useUploader } from "@w3ui/react-uploader";
-import { useUploadsList } from "@w3ui/react-uploads-list";
-import ImageListItem from "../components/ImageListItem";
+import { useState, useRef, useEffect } from "react";
+import { useUploader } from '@w3ui/react-uploader'
+import { useUploadsList } from '@w3ui/react-uploads-list'
+
+import { withIdentity } from "../components/Authenticator";
+import ImageListItem from '../components/ImageListItem';
 
 export function Home() {
   const camera = useRef(null);
@@ -11,15 +12,14 @@ export function Home() {
   const [status, setStatus] = useState("");
   const [error, setError] = useState(null);
   const [images, setImages] = useState([]);
+  
+  const [{ data: listData }, { next: listNext }] = useUploadsList();
+  // load the first page of uploads
+  useEffect(() => {
+    listNext()
+  }, [])
 
-  const {
-    loading,
-    error: listError,
-    data: listData,
-    reload: listReload,
-  } = useUploadsList();
-  const printListData = (listData && listData.results) || [];
-
+  const printListData = listData || []
   const printStatus = status === "done" && error ? error.message : status;
 
   const takePhoto = async (e) => {
@@ -58,7 +58,7 @@ export function Home() {
         {images.map(({ cid, data }) => (
           <ImageListItem key={cid} cid={cid} data={data} />
         ))}
-        {printListData.map(({ dataCid: cid }) => (
+        {printListData.map(({ root: cid }) => (
           <ImageListItem key={cid} cid={cid} />
         ))}
       </ul>
@@ -66,4 +66,4 @@ export function Home() {
   );
 }
 
-export default withIdentity(Home);
+export default withIdentity(Home)

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,57 +139,66 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
-"@ipld/car@^4.1.5":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@ipld/car/-/car-4.1.6.tgz#81bae5c3454dbc0db6291107d99bcc8792588d7f"
-  integrity sha512-qs3Sco7rm1PRhhuGSWpCeayhqcB/0DOyIgBiqsfjV0mT0JbWs68Z+BTxksONlfindRXsM5llJOvZfAcuEJUqxw==
+"@ipld/car@^5.0.0", "@ipld/car@^5.0.1":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@ipld/car/-/car-5.0.3.tgz#9c82961aaa4ffa2d941f79fd243f8bb9e8e9dd13"
+  integrity sha512-omPSY65OSVmlFGJDn2xbd75o71GNHmgP5u2dQ5fITc0X/QqJZVfZi95NCs8oa1wWhjkaK3RTswRSg2iNqFUSAg==
   dependencies:
-    "@ipld/dag-cbor" "^7.0.0"
+    "@ipld/dag-cbor" "^9.0.0"
     cborg "^1.9.0"
-    multiformats "^9.5.4"
+    multiformats "^11.0.0"
     varint "^6.0.0"
 
-"@ipld/dag-cbor@^7.0.0", "@ipld/dag-cbor@^7.0.1", "@ipld/dag-cbor@^7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@ipld/dag-cbor/-/dag-cbor-7.0.3.tgz#aa31b28afb11a807c3d627828a344e5521ac4a1e"
-  integrity sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==
+"@ipld/dag-cbor@^8.0.0":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@ipld/dag-cbor/-/dag-cbor-8.0.1.tgz#3042c219dd85a71d66ca6946fb6c7b6f0d519369"
+  integrity sha512-mHRuzgGXNk0Y5W7nNQdN37qJiig1Kdgf92icBVFRUNtBc9Ezl5DIdWfiGWBucHBrhqPBncxoH3As9cHPIRozxA==
   dependencies:
     cborg "^1.6.0"
-    multiformats "^9.5.4"
+    multiformats "^11.0.0"
 
-"@ipld/dag-json@^8.0.9":
-  version "8.0.11"
-  resolved "https://registry.yarnpkg.com/@ipld/dag-json/-/dag-json-8.0.11.tgz#8d30cc2dfacb0aef04d327465d3df91e79e8b6ce"
-  integrity sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==
+"@ipld/dag-cbor@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@ipld/dag-cbor/-/dag-cbor-9.0.0.tgz#51902f7d19ce2203b04e4cfe0514936b82d09d91"
+  integrity sha512-zdsiSiYDEOIDW7mmWOYWC9gukjXO+F8wqxz/LfN7iSwTfIyipC8+UQrCbPupFMRb/33XQTZk8yl3My8vUQBRoA==
   dependencies:
-    cborg "^1.5.4"
-    multiformats "^9.5.4"
+    cborg "^1.10.0"
+    multiformats "^11.0.0"
 
-"@ipld/dag-pb@^2.1.15":
-  version "2.1.18"
-  resolved "https://registry.yarnpkg.com/@ipld/dag-pb/-/dag-pb-2.1.18.tgz#12d63e21580e87c75fd1a2c62e375a78e355c16f"
-  integrity sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==
+"@ipld/dag-json@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@ipld/dag-json/-/dag-json-10.0.0.tgz#0b2a3f679837023c33b2ef1e878cb6ec9e9ad9da"
+  integrity sha512-u/PfR2sT9AiZZDUl1VNspx3OP13zuvBXAd3sKiURlSOoWfoLigxTCs+sXeaXA0hoXU7u1M2DECMt4LCUHuApSA==
   dependencies:
-    multiformats "^9.5.4"
+    cborg "^1.10.0"
+    multiformats "^11.0.0"
 
-"@ipld/dag-ucan@3.0.0-beta":
-  version "3.0.0-beta"
-  resolved "https://registry.yarnpkg.com/@ipld/dag-ucan/-/dag-ucan-3.0.0-beta.tgz#7657104d96d0222a163564d6bb508995f4af2c63"
-  integrity sha512-WzKh4mDiUElslfI/cg9VjLNHsT+9r3XjwbDY/gck+1289sCU1Hywj1/9PMx0DMJoEEwd2OFy/bq5PX2IyQ20Cw==
+"@ipld/dag-pb@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@ipld/dag-pb/-/dag-pb-4.0.0.tgz#1c737a3b47d91d5c7851cd654b98b66fcd73e855"
+  integrity sha512-8FB/qTlNowCiszL9Sek8xH6xIQxIioXuzZ5B1jVPknQMVkd08nZUHzDjrn1Y6MqJ5PrXWLrBwNghGMWPPpvNVw==
   dependencies:
-    "@ipld/dag-cbor" "^7.0.1"
-    "@ipld/dag-json" "^8.0.9"
-    multiformats "^9.6.4"
+    multiformats "^11.0.0"
 
-"@ipld/unixfs@^1.1.0-dev":
-  version "1.1.0-dev"
-  resolved "https://registry.yarnpkg.com/@ipld/unixfs/-/unixfs-1.1.0-dev.tgz#6e0460751cf8226d0ae980d4405de5f7970c0f54"
-  integrity sha512-rLMc49JZtghx2s1Ed9iAvC35PtImREMdk4on3830nOH7ohL3QGwi4dB2rtE2vPvgJonHuImP9BMK+4AcFFWMZQ==
+"@ipld/dag-ucan@^3.0.1", "@ipld/dag-ucan@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@ipld/dag-ucan/-/dag-ucan-3.2.0.tgz#5c3cdf3c6f8ee7e96bd5fec98dd28c729e2f3229"
+  integrity sha512-CTClaGx4F3iEMJgYaYVOVBEvtNXzPc77Mi6p3vBtylSzDWhbf1Gou9ij7PlblOqWKA1H7XI8fp6yweTb6iXNKQ==
   dependencies:
-    "@ipld/dag-pb" "^2.1.15"
+    "@ipld/dag-cbor" "^9.0.0"
+    "@ipld/dag-json" "^10.0.0"
+    multiformats "^11.0.0"
+
+"@ipld/unixfs@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@ipld/unixfs/-/unixfs-2.0.1.tgz#5787a484afa6b1cddd5fa0493073784d54618768"
+  integrity sha512-W3LD67tLrIGpCVYFN6N/x6bL3o03zmsfd7jPAD1aXfGXaQWWa95qXPwc6PMVRTttxha/bHMKQiG2ZeFCqp83Ew==
+  dependencies:
+    "@ipld/dag-pb" "^4.0.0"
     "@web-std/stream" "1.0.1"
-    actor "^2.3.0"
-    protobufjs "^6.11.2"
+    actor "^2.3.1"
+    multiformats "^11.0.1"
+    protobufjs "^7.1.2"
     rabin-rs "^2.1.0"
 
 "@jridgewell/gen-mapping@^0.3.2":
@@ -294,7 +303,7 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.1.tgz#469dde61519f6a310874af93ee5969f1d5ff6d03"
   integrity sha512-t/0G33t/6VGWZUGCOT7rG42qqvf/x+MrFp1CU+8CN6PrjSSL57R5bqkXfubV9t4eCEnUxVP+5Hn3MoEXEebtEw==
 
-"@noble/ed25519@^1.7.0", "@noble/ed25519@^1.7.1":
+"@noble/ed25519@^1.7.1":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.1.tgz#6899660f6fbb97798a6fbd227227c4589a454724"
   integrity sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==
@@ -359,15 +368,10 @@
   dependencies:
     tslib "^2.4.0"
 
-"@types/long@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
-  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
-
-"@types/node@*", "@types/node@>=13.7.0":
-  version "18.11.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
-  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
+"@types/node@>=13.7.0":
+  version "18.11.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
+  integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
 
 "@types/retry@0.12.1":
   version "0.12.1"
@@ -379,223 +383,179 @@
   resolved "https://registry.yarnpkg.com/@types/webrtc/-/webrtc-0.0.25.tgz#bd2b4e7b4c13250b3d58439623f2b9adfd7dee9e"
   integrity sha512-ep/e+p2uUKV1h96GBgRhwomrBch/bPDHPOKbCHODLGRUDuuKe2s7sErlFVKw+5BYUzvpxSmUNqoadaZ44MePoQ==
 
-"@types/ws@^8.5.3":
-  version "8.5.3"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
-  integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
-  dependencies:
-    "@types/node" "*"
-
-"@ucanto/client@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@ucanto/client/-/client-1.0.1.tgz#a4e3524fc4c5fb62a0a139d889d43309a6c4fb68"
-  integrity sha512-ZWOCVDXdKhq0r5ZRUN5ubqpfjsQ2Nra2WFv2AyHZWSHA+maI4FA/btJBOWUPHW3BtWNDSt4waEfYXXh4iqkN0g==
-  dependencies:
-    "@ucanto/interface" "^1.0.0"
-    multiformats "^9.8.1"
-
-"@ucanto/core@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@ucanto/core/-/core-1.0.1.tgz#8a41afc11cff8fffd0dee8406a15cda55f396568"
-  integrity sha512-ugGyxbVwe1W7yYiVf281uZqZ5RgZ9f89JK29zQmmU3fv83wO3xIt5cWAr2ctXUAaRKmY0s3kZcMlEYemDDYm+A==
-  dependencies:
-    "@ipld/car" "^4.1.5"
-    "@ipld/dag-cbor" "^7.0.3"
-    "@ipld/dag-ucan" "3.0.0-beta"
-    "@ucanto/interface" "^1.0.0"
-    multiformats "^9.8.1"
-
-"@ucanto/interface@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ucanto/interface/-/interface-1.0.0.tgz#f28bc409387121a2e94cda7600e795e430214b3f"
-  integrity sha512-qVsFx7YsPnc5QaGfDGyFaj/M3wog+E/A0dX1LJn+K5GQ6DWd3nKvv+rxfZ888ZU+36gDdji8/R1qfT8GngNTMQ==
-  dependencies:
-    "@ipld/dag-ucan" "3.0.0-beta"
-    multiformats "^9.8.1"
-
-"@ucanto/principal@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@ucanto/principal/-/principal-1.0.1.tgz#7f97de97e04735e19f32f87df53f46e4d3e3e840"
-  integrity sha512-tuIhJRCj8Plk/XraHlPkOc9WsMsFOyQ9jcYRquD3/ybah4Nh843+eSPfDcOUnB1Y4FJg2wT4R8OEnTZejE7+dA==
-  dependencies:
-    "@ipld/dag-ucan" "3.0.0-beta"
-    "@noble/ed25519" "^1.7.0"
-    "@ucanto/interface" "^1.0.0"
-    multiformats "^9.8.1"
-
-"@ucanto/server@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@ucanto/server/-/server-1.0.2.tgz#349341e937ff444df3d48a5f686a8449cfbbbe31"
-  integrity sha512-ECXv8y8WM/Do9MSb8DLYbRY7yRvL6VdQL2v1YfU5USjAyNPyjP73M+zpXf7tEhdXcZbqn/JIws3H21J56i7oog==
-  dependencies:
-    "@ucanto/core" "^1.0.1"
-    "@ucanto/interface" "^1.0.0"
-    "@ucanto/validator" "^1.0.1"
-
-"@ucanto/transport@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@ucanto/transport/-/transport-1.0.1.tgz#cfffcf7c0ee66076bfb61df1df8fd38404a1974e"
-  integrity sha512-zC7ty7l5F47C8uWiZajs8MwplR8KoAGIz72psSrB6R+Zx9Le+SoN2/gyPD0a4cDtpMLEyHOPodOlBTnQEIlEcQ==
-  dependencies:
-    "@ipld/car" "^4.1.5"
-    "@ipld/dag-cbor" "^7.0.3"
-    "@ucanto/core" "^1.0.1"
-    "@ucanto/interface" "^1.0.0"
-    multiformats "^9.8.1"
-
-"@ucanto/validator@^1.0.1", "@ucanto/validator@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@ucanto/validator/-/validator-1.0.2.tgz#3230eea32977c192b6b42adeb7cd3ca00f584495"
-  integrity sha512-SFjS/8FDOwzPNM29brT6wgbE+HXD8iQnHR3aeqEgzIUL7j56kluZykfVWD0xR8oLn8vYzNqJqf60YeFAbIBsqg==
-  dependencies:
-    "@ipld/car" "^4.1.5"
-    "@ipld/dag-cbor" "^7.0.3"
-    "@ucanto/core" "^1.0.1"
-    "@ucanto/interface" "^1.0.0"
-    multiformats "^9.8.1"
-
-"@w3ui/keyring-core@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@w3ui/keyring-core/-/keyring-core-1.0.2.tgz#0f69a9d380671e4370195ef2928373286f8f138c"
-  integrity sha512-IujXoTV1VtnqUtscSoeaqwuOhKRoHOc/u9gP/oTlhZ8B2ueaDIcn6Cfd9D1uQuDY5c62o0QC0WIwWiqleQ17Kg==
-  dependencies:
-    "@ucanto/interface" "^1.0.0"
-    "@ucanto/principal" "^1.0.1"
-    "@web3-storage/access" "^2.1.1"
-    multiformats "^9.8.1"
-
-"@w3ui/react-keyring@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@w3ui/react-keyring/-/react-keyring-1.0.1.tgz#b4914a7404cc6cb538c8a563de8ab018b4ed557b"
-  integrity sha512-XrgVZ6yrT4SrA0G5Ry3far7MlB1fxKgXz0w+EVyxo40slQUaXmJZY9PZUTG6U7ydnDkN2BCj22++h+lHUS4nWw==
-  dependencies:
-    "@w3ui/keyring-core" "^1.0.2"
-
-"@w3ui/react-uploader@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@w3ui/react-uploader/-/react-uploader-2.1.2.tgz#b34e4f99c8532041aaf566dd775d2b30a8d78597"
-  integrity sha512-9BeWNaoq99SuwOhxRvMxUKU+PUThbbiq0ZRnWQZ3LuZGBv/RB1LjV1oyfxDqUudl8m0xaYVgVRKCNHpLt78PzA==
-  dependencies:
-    "@w3ui/uploader-core" "^2.0.2"
-    multiformats "^9.9.0"
-
-"@w3ui/react-uploads-list@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@w3ui/react-uploads-list/-/react-uploads-list-1.1.2.tgz#e92bd2e45a761853739692126230fd9244c33337"
-  integrity sha512-L1tFUgjaHWuaxK7j0Q7d9D8sJd0HLtsWXzFdmW53QC43KQ18lYXaAKVxjRFQZ7453Y3RfJqfkEil3eIsV3TYOQ==
-  dependencies:
-    "@w3ui/uploads-list-core" "^1.0.3"
-
-"@w3ui/uploader-core@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@w3ui/uploader-core/-/uploader-core-2.0.2.tgz#d5d53e76b7ec16807cd69d6e7c5349ad4e6e1b83"
-  integrity sha512-QSKrq24THyMztyzAhdif8ajhMewaTTTVYnwq/sjVj2TXsXE8XeY6J0qKko0w+QtEy0A47SnbrHevtNLq4KGP2A==
-  dependencies:
-    "@ipld/car" "^4.1.5"
-    "@ipld/unixfs" "^1.1.0-dev"
-    "@ucanto/interface" "^1.0.0"
-    "@ucanto/principal" "^1.0.1"
-    "@ucanto/transport" "^1.0.1"
-    "@web3-storage/access" "^2.1.1"
-    multiformats "^9.8.1"
-    p-retry "^5.1.1"
-    streaming-iterables "^7.1.0"
-
-"@w3ui/uploads-list-core@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@w3ui/uploads-list-core/-/uploads-list-core-1.0.3.tgz#33ccaf6e148e7b459600fc9785a9f48af664d486"
-  integrity sha512-IEsRxjYI3eUogksunInK8TFwTNy47B9pg/LsXbGOKyWKeIH2TK1rgC+hht0P03Ng8yY2ANg+WzccLgK8Tmj2ew==
-  dependencies:
-    "@ucanto/interface" "^1.0.0"
-    "@ucanto/principal" "^1.0.1"
-    "@web3-storage/access" "^2.1.1"
-    multiformats "^9.9.0"
-
-"@web-std/blob@^3.0.3":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@web-std/blob/-/blob-3.0.4.tgz#dd67a685547331915428d69e723c7da2015c3fc5"
-  integrity sha512-+dibyiw+uHYK4dX5cJ7HA+gtDAaUUe6JsOryp2ZpAC7h4ICsh49E34JwHoEKPlPvP0llCrNzz45vvD+xX5QDBg==
-  dependencies:
-    "@web-std/stream" "1.0.0"
-    web-encoding "1.1.5"
-
-"@web-std/fetch@^4.1.0":
+"@ucanto/client@^4.0.3":
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@web-std/fetch/-/fetch-4.1.0.tgz#db1eb659198376dad692421896b7119fb13e6e52"
-  integrity sha512-ZRizMcP8YyuRlhIsRYNFD9x/w28K7kbUhNGmKM9hDy4qeQ5xMTk//wA89EF+Clbl6EP4ksmCcN+4TqBMSRL8Zw==
+  resolved "https://registry.yarnpkg.com/@ucanto/client/-/client-4.1.0.tgz#7e9282086e40458aa1d5612b86ef7a8af436c56c"
+  integrity sha512-Sn24Z5+g+MbuopGEXaBXqrrite8TwSUVHvuXHPfnSco7PtZ0Zu7siTXKrHp15dTbVN2tkvdZTSxB0UZsMmOGPA==
   dependencies:
-    "@web-std/blob" "^3.0.3"
-    "@web-std/form-data" "^3.0.2"
-    "@web-std/stream" "^1.0.1"
-    "@web3-storage/multipart-parser" "^1.0.0"
-    data-uri-to-buffer "^3.0.1"
-    mrmime "^1.0.0"
+    "@ucanto/interface" "^4.1.0"
+    multiformats "^11.0.0"
 
-"@web-std/form-data@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@web-std/form-data/-/form-data-3.0.2.tgz#c71d9def6a593138ea92fe3d1ffbce19f43e869c"
-  integrity sha512-rhc8IRw66sJ0FHcnC84kT3mTN6eACTuNftkt1XSl1Ef6WRKq4Pz65xixxqZymAZl1K3USpwhLci4SKNn4PYxWQ==
+"@ucanto/core@^4.0.2", "@ucanto/core@^4.0.3", "@ucanto/core@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@ucanto/core/-/core-4.1.0.tgz#648892c9466279ea833cb3185afb87cdca8ac62f"
+  integrity sha512-uH3ViPWB1/K2eeQyTS7nOpupcQ0VC0qzPMYpMD1e0WSTrwVYGwMs0ttG4J77fqXExul46rLCPTY/2R7Tstn7xQ==
   dependencies:
-    web-encoding "1.1.5"
+    "@ipld/car" "^5.0.0"
+    "@ipld/dag-cbor" "^8.0.0"
+    "@ipld/dag-ucan" "^3.2.0"
+    "@ucanto/interface" "^4.1.0"
+    multiformats "^11.0.0"
 
-"@web-std/stream@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@web-std/stream/-/stream-1.0.0.tgz#01066f40f536e4329d9b696dc29872f3a14b93c1"
-  integrity sha512-jyIbdVl+0ZJyKGTV0Ohb9E6UnxP+t7ZzX4Do3AHjZKxUXKMs9EmqnBDQgHF7bEw0EzbQygOjtt/7gvtmi//iCQ==
+"@ucanto/interface@^4.0.2", "@ucanto/interface@^4.0.3", "@ucanto/interface@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@ucanto/interface/-/interface-4.1.0.tgz#804f23f3d3807c9eab4161c82956377567afb19e"
+  integrity sha512-vqHUcMPk1tPIJbCT2X5dBRrUUSz5CUKiMJv6GOP24JournjqcwHTr4GqhXZEYgA2yAv/H+CcfVR5mWfnmLd+MQ==
   dependencies:
-    web-streams-polyfill "^3.1.1"
+    "@ipld/dag-ucan" "^3.2.0"
+    multiformats "^11.0.0"
 
-"@web-std/stream@1.0.1", "@web-std/stream@^1.0.1":
+"@ucanto/principal@^4.0.2", "@ucanto/principal@^4.0.3":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@ucanto/principal/-/principal-4.1.0.tgz#c64ba57c6ff05d98bc3ee24ae6fe7046427a1f9b"
+  integrity sha512-R4YdxXkBr4cbmUj7bZKDtdxkfqlT60jYSS2JCtzzxYsSmxRKIjKR/a4Nmo7pqX40vSfqrvp4WlZAzl9Lczuw2A==
+  dependencies:
+    "@ipld/dag-ucan" "^3.2.0"
+    "@noble/ed25519" "^1.7.1"
+    "@ucanto/interface" "^4.1.0"
+    multiformats "^11.0.0"
+    one-webcrypto "^1.0.3"
+
+"@ucanto/transport@^4.0.2", "@ucanto/transport@^4.0.3":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@ucanto/transport/-/transport-4.1.0.tgz#bc5fb26eb2ecb9d947d4c02c696ad32df44721b6"
+  integrity sha512-Bd/Ma5K0rv+OOBjnisOxfhq1iFWvCn1VtFwtuzqjZGUNt7HdefJazBfpA1wILd+lLw8Krx2gr+7RHbLfQmLXtQ==
+  dependencies:
+    "@ipld/car" "^5.0.0"
+    "@ipld/dag-cbor" "^8.0.0"
+    "@ucanto/core" "^4.1.0"
+    "@ucanto/interface" "^4.1.0"
+    multiformats "^11.0.0"
+
+"@ucanto/validator@^4.0.2", "@ucanto/validator@^4.0.3":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@ucanto/validator/-/validator-4.1.0.tgz#e1faf12cedb04c9bfbccce1fb3fa30a610fd455c"
+  integrity sha512-YARh2hR4YafJpeKp1UmLzQUjjdpYE5cO9aVfmJVRbQMqyYz50VvkICm1dhp/7VyO4/H8oJM8WVhxiuo5eJv+ZA==
+  dependencies:
+    "@ipld/car" "^5.0.0"
+    "@ipld/dag-cbor" "^8.0.0"
+    "@ucanto/core" "^4.1.0"
+    "@ucanto/interface" "^4.1.0"
+    multiformats "^11.0.0"
+
+"@w3ui/keyring-core@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@w3ui/keyring-core/-/keyring-core-2.0.1.tgz#53cd32a72fcd7c9747863a502f5604032251b2d4"
+  integrity sha512-ZLz72omNf++uMCyfuDdL58AB8wnYUO/RC20JyGBXpf0K7wfkI9co8B/YQ/pGK9dCk5P7hSGQ/9hgHTHQi0UK9A==
+  dependencies:
+    "@web3-storage/access" "^9.2.0"
+
+"@w3ui/react-keyring@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@w3ui/react-keyring/-/react-keyring-2.0.1.tgz#8ff6f14508cab48f5634f2a559f3eff6330f3efb"
+  integrity sha512-cRqNEbhLsRNulWR9k1uUxXyFbpTSbHwqzn07b5Pmfr/3i2Zf5uaIOWVh3mgIKBkjr1rlUmGNr27IzlMSKDe2mQ==
+  dependencies:
+    "@w3ui/keyring-core" "^2.0.1"
+
+"@w3ui/react-uploader@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@w3ui/react-uploader/-/react-uploader-3.0.1.tgz#3cd14be85ee423d73fe12b08b5f7ae5894273a22"
+  integrity sha512-rnNRKhp3znuXEX41UwyrCSQfkSk9R5PgeagivAdvtF+KzU75/TyLTaPURCJfapc4ADogfzRuSqAMAgKGw03dEA==
+  dependencies:
+    "@w3ui/uploader-core" "^3.0.1"
+    "@web3-storage/capabilities" "^2.0.0"
+    multiformats "^10.0.2"
+
+"@w3ui/react-uploads-list@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@w3ui/react-uploads-list/-/react-uploads-list-2.0.1.tgz#9ea08d8a0ed4b3eb38e782f07f1d3358030dd9b7"
+  integrity sha512-Xxmfv3eCamGAN59WaFAS0YymCb6H0oxH/ZBBVW7A7yCB4tgD1/OpZ1upXtqu9bb93aSoyA312tzo4PkOmBsGkw==
+  dependencies:
+    "@w3ui/uploads-list-core" "^2.0.1"
+    "@web3-storage/capabilities" "^2.0.0"
+
+"@w3ui/uploader-core@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@w3ui/uploader-core/-/uploader-core-3.0.1.tgz#a6d8e3ea84d8bb9b878faeb7070790f0599ae60f"
+  integrity sha512-XrnC8coDFT4hSToLqudMxKtFx/dpsVUMCohJMyPhLFoICZWFzfMzPlouTjxy1oC3N9UczFtLYRDYVRcfQSuyeQ==
+  dependencies:
+    "@web3-storage/upload-client" "^5.2.0"
+    multiformats "^10.0.2"
+
+"@w3ui/uploads-list-core@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@w3ui/uploads-list-core/-/uploads-list-core-2.0.1.tgz#2ca1a9b9cc957a2728d0f98e7fc1b6582ab83657"
+  integrity sha512-P36KF3nC6SW+i4sFOQx1KSFJWStBwVyhBOiJ+jG6JOAapYzomIRZCDvwifFjl+xhV+UKp/C11bksbiZhbMRM/A==
+  dependencies:
+    "@ucanto/interface" "^4.0.3"
+    "@web3-storage/upload-client" "^5.2.0"
+
+"@web-std/stream@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@web-std/stream/-/stream-1.0.1.tgz#af2972654848e20a683781b0a50bef2ce3f011a0"
   integrity sha512-tsz4Y0WNDgFA5jwLSeV7/UV5rfMIlj0cPsSLVfTihjaVW0OJPd5NxJ3le1B3yLyqqzRpeG5OAfJAADLc4VoGTA==
   dependencies:
     web-streams-polyfill "^3.1.1"
 
-"@web3-storage/access@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@web3-storage/access/-/access-2.1.1.tgz#8ba3f5f0aaf15a1703924a9e9d5471ae0e1fca96"
-  integrity sha512-8MGs3gY6dn/KrJE+X4GDnwrPXaPgm5lvGJKFJpMdYVBtTUjfWQx9mhdYErs2nE2JEt9tKubCfe1rgodZ1b+7gA==
+"@web3-storage/access@^9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@web3-storage/access/-/access-9.2.0.tgz#08299ffe4126a424b6efc4992cd7dba838af8440"
+  integrity sha512-6H/MtlTcEsDB7Ek+mTPg3tA5AhvzeMJt68gbcYzl71IooMrTKK46ZCMa//wxt0+fgOFGo0YX0jyE7fcRj4Vmnw==
   dependencies:
-    "@ipld/car" "^4.1.5"
-    "@ipld/dag-ucan" "3.0.0-beta"
-    "@noble/ed25519" "^1.7.1"
-    "@types/ws" "^8.5.3"
-    "@ucanto/client" "^1.0.1"
-    "@ucanto/core" "^1.0.1"
-    "@ucanto/interface" "^1.0.0"
-    "@ucanto/principal" "^1.0.1"
-    "@ucanto/server" "^1.0.2"
-    "@ucanto/transport" "^1.0.1"
-    "@ucanto/validator" "^1.0.2"
-    "@web-std/fetch" "^4.1.0"
-    bigint-mod-arith "^3.1.1"
-    conf "^10.1.2"
-    inquirer "^9.1.2"
+    "@ipld/car" "^5.0.1"
+    "@ipld/dag-cbor" "^8.0.0"
+    "@ipld/dag-ucan" "^3.0.1"
+    "@ucanto/client" "^4.0.3"
+    "@ucanto/core" "^4.0.3"
+    "@ucanto/interface" "^4.0.3"
+    "@ucanto/principal" "^4.0.3"
+    "@ucanto/transport" "^4.0.3"
+    "@ucanto/validator" "^4.0.3"
+    "@web3-storage/capabilities" "^2.1.0"
+    bigint-mod-arith "^3.1.2"
+    conf "^10.2.0"
+    inquirer "^9.1.4"
     isomorphic-ws "^5.0.0"
-    multiformats "^9.8.1"
-    nanoid "^4.0.0"
+    kysely "^0.22.0"
+    multiformats "^10.0.2"
     one-webcrypto "^1.0.3"
     ora "^6.1.2"
-    p-queue "^7.3.0"
-    p-retry "^5.1.1"
+    p-defer "^4.0.0"
     p-wait-for "^5.0.0"
-    uint8arrays "^3.1.0"
-    undici "^5.10.0"
-    ws "^8.8.1"
-    zod "^3.19.1"
+    type-fest "^3.3.0"
+    uint8arrays "^4.0.2"
+    varint "^6.0.0"
+    ws "^8.11.0"
+    zod "^3.20.2"
 
-"@web3-storage/multipart-parser@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz#6b69dc2a32a5b207ba43e556c25cc136a56659c4"
-  integrity sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==
+"@web3-storage/capabilities@^2.0.0", "@web3-storage/capabilities@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@web3-storage/capabilities/-/capabilities-2.1.0.tgz#6df6337489a30157e6412052d3d5ab446d95ed09"
+  integrity sha512-6rbcushGhbaeHC38iTEW8t6QapJutfDxLoKPEVMHTJYUGfKE/bL7M7VYXws6Vdp1XCFaLbLv88OSIR/nq9M9lg==
+  dependencies:
+    "@ucanto/core" "^4.0.2"
+    "@ucanto/interface" "^4.0.2"
+    "@ucanto/principal" "^4.0.2"
+    "@ucanto/transport" "^4.0.2"
+    "@ucanto/validator" "^4.0.2"
 
-"@zxing/text-encoding@0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
-  integrity sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==
+"@web3-storage/upload-client@^5.2.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@web3-storage/upload-client/-/upload-client-5.3.0.tgz#1899cab945fda224573ff0ef6f715d8dd0e5e959"
+  integrity sha512-3vLErJTiigQ/cSlg8mCrOz3ZV1AZeGgeKDvmDhOBSaIY5rBvKzW2Bjcu4Vqv1cLdWOz2qkg6Tp6X+0qRV0cfPA==
+  dependencies:
+    "@ipld/car" "^5.0.0"
+    "@ipld/dag-ucan" "^3.0.1"
+    "@ipld/unixfs" "^2.0.0"
+    "@ucanto/client" "^4.0.3"
+    "@ucanto/interface" "^4.0.3"
+    "@ucanto/transport" "^4.0.3"
+    "@web3-storage/capabilities" "^2.1.0"
+    multiformats "^10.0.2"
+    p-queue "^7.3.0"
+    p-retry "^5.1.2"
 
-actor@^2.3.0:
+actor@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/actor/-/actor-2.3.1.tgz#80ce158bb41338a0c38863bddf0947c1850b6e20"
   integrity sha512-ST/3wnvcP2tKDXnum7nLCLXm+/rsf8vPocXH2Fre6D8FQwNkGDd4JEitBlXj007VQJfiGYRQvXqwOBZVi+JtRg==
@@ -608,9 +568,9 @@ ajv-formats@^2.1.1:
     ajv "^8.0.0"
 
 ajv@^8.0.0, ajv@^8.6.3:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
-  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -646,11 +606,6 @@ atomically@^1.7.0:
   resolved "https://registry.yarnpkg.com/atomically/-/atomically-1.7.0.tgz#c07a0458432ea6dbc9a3506fffa424b48bccaafe"
   integrity sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==
 
-available-typed-arrays@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
-  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
-
 "babel-plugin-styled-components@>= 1.12.0":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz#c81ef34b713f9da2b7d3f5550df0d1e19e798086"
@@ -672,7 +627,7 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-bigint-mod-arith@^3.1.1:
+bigint-mod-arith@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bigint-mod-arith/-/bigint-mod-arith-3.1.2.tgz#658e416bc593a463d97b59766226d0a3021a76b1"
   integrity sha512-nx8J8bBeiRR+NlsROFH9jHswW5HO8mgfOSqW0AmjicMMvaONDa8AO+5ViKDUUNytBPWiwfvZP4/Bj4Y3lUfvgQ==
@@ -694,21 +649,6 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
-busboy@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
-  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
-  dependencies:
-    streamsearch "^1.1.0"
-
-call-bind@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
-  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
-  dependencies:
-    function-bind "^1.1.1"
-    get-intrinsic "^1.0.2"
-
 camelize@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
@@ -719,10 +659,10 @@ caniuse-lite@^1.0.30001406:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz#70cdae959096756a85713b36dd9cb82e62325639"
   integrity sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg==
 
-cborg@^1.5.4, cborg@^1.6.0, cborg@^1.9.0:
-  version "1.9.5"
-  resolved "https://registry.yarnpkg.com/cborg/-/cborg-1.9.5.tgz#1e3b8a8407b3665566001f8841c9d72d7a80b2d5"
-  integrity sha512-fLBv8wmqtlXqy1Yu+pHzevAIkW6k2K0ZtMujNzWphLsA34vzzg9BHn+5GmZqOJkSA9V7EMKsWrf6K976c1QMjQ==
+cborg@^1.10.0, cborg@^1.6.0, cborg@^1.9.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/cborg/-/cborg-1.10.0.tgz#0fe157961dd47b537ccb84dc9ba681de8b699013"
+  integrity sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -734,9 +674,9 @@ chalk@^2.0.0:
     supports-color "^5.3.0"
 
 chalk@^5.0.0, chalk@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.1.2.tgz#d957f370038b75ac572471e83be4c5ca9f8e8c45"
-  integrity sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
+  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -782,7 +722,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-conf@^10.1.2:
+conf@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/conf/-/conf-10.2.0.tgz#838e757be963f1a2386dfe048a98f8f69f7b55d6"
   integrity sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==
@@ -811,11 +751,6 @@ css-to-react-native@^3.0.0:
     camelize "^1.0.0"
     css-color-keywords "^1.0.0"
     postcss-value-parser "^4.0.2"
-
-data-uri-to-buffer@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
-  integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
 
 debounce-fn@^4.0.0:
   version "4.0.0"
@@ -909,62 +844,15 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-for-each@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
-  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
-  dependencies:
-    is-callable "^1.1.3"
-
-function-bind@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
-  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
-
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
-  integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
-  dependencies:
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-symbols "^1.0.3"
-
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-gopd@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
-  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
-  dependencies:
-    get-intrinsic "^1.1.3"
-
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
-
-has-symbols@^1.0.2, has-symbols@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
-  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
-
-has-tostringtag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
-  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
-  dependencies:
-    has-symbols "^1.0.2"
-
-has@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
-  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
-  dependencies:
-    function-bind "^1.1.1"
 
 hoist-non-react-statics@^3.0.0:
   version "3.3.2"
@@ -990,7 +878,7 @@ inherits@^2.0.3, inherits@^2.0.4:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-inquirer@^9.1.2:
+inquirer@^9.1.4:
   version "9.1.4"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-9.1.4.tgz#482da8803670a64bd942bc5166a9547a19d41474"
   integrity sha512-9hiJxE5gkK/cM2d1mTEnuurGTAoHebbkX0BYl3h7iEg7FYfuNIom+nDfBCSWtvSnoSrWCeBxqqBZu26xdlJlXA==
@@ -1011,26 +899,6 @@ inquirer@^9.1.2:
     through "^2.3.6"
     wrap-ansi "^8.0.1"
 
-is-arguments@^1.0.4:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
-  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
-  dependencies:
-    call-bind "^1.0.2"
-    has-tostringtag "^1.0.0"
-
-is-callable@^1.1.3:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
-  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
-
-is-generator-function@^1.0.7:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
-  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
-  dependencies:
-    has-tostringtag "^1.0.0"
-
 is-interactive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-2.0.0.tgz#40c57614593826da1100ade6059778d597f16e90"
@@ -1040,17 +908,6 @@ is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
   integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
-
-is-typed-array@^1.1.10, is-typed-array@^1.1.3:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
-  integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
-  dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    for-each "^0.3.3"
-    gopd "^1.0.1"
-    has-tostringtag "^1.0.0"
 
 is-unicode-supported@^1.1.0, is-unicode-supported@^1.2.0:
   version "1.3.0"
@@ -1082,6 +939,11 @@ json-schema-typed@^7.0.3:
   resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-7.0.3.tgz#23ff481b8b4eebcd2ca123b4fa0409e66469a2d9"
   integrity sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==
 
+kysely@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/kysely/-/kysely-0.22.0.tgz#8aac53942da3cadc604d7d154a746d983fe8f7b9"
+  integrity sha512-ZE3qWtnqLOalodzfK5QUEcm7AEulhxsPNuKaGFsC3XiqO92vMLm+mAHk/NnbSIOtC4RmGm0nsv700i8KDp1gfQ==
+
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -1103,10 +965,10 @@ log-symbols@^5.1.0:
     chalk "^5.0.0"
     is-unicode-supported "^1.1.0"
 
-long@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
-  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+long@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.1.tgz#e27595d0083d103d2fa2c20c7699f8e0c92b897f"
+  integrity sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==
 
 loose-envify@^1.1.0:
   version "1.4.0"
@@ -1132,20 +994,20 @@ mimic-fn@^3.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
   integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
 
-mrmime@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
-  integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-multiformats@^9.4.2, multiformats@^9.5.4, multiformats@^9.6.4, multiformats@^9.8.1, multiformats@^9.9.0:
-  version "9.9.0"
-  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.9.0.tgz#c68354e7d21037a8f1f8833c8ccd68618e8f1d37"
-  integrity sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==
+multiformats@^10.0.2:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-10.0.3.tgz#d4147d01f9a31271c6fb5d24adf9b01f9e656bba"
+  integrity sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw==
+
+multiformats@^11.0.0, multiformats@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-11.0.1.tgz#ba58c3f69f032ab67dab4b48cc70f01ac2ca07fe"
+  integrity sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==
 
 mute-stream@0.0.8:
   version "0.0.8"
@@ -1156,11 +1018,6 @@ nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
-
-nanoid@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.0.tgz#6e144dee117609232c3f415c34b0e550e64999a5"
-  integrity sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==
 
 next@13.0.1:
   version "13.0.1"
@@ -1220,6 +1077,11 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
+p-defer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-4.0.0.tgz#8082770aeeb10eb6b408abe91866738741ddd5d2"
+  integrity sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==
+
 p-limit@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -1242,10 +1104,10 @@ p-queue@^7.3.0:
     eventemitter3 "^4.0.7"
     p-timeout "^5.0.2"
 
-p-retry@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-5.1.1.tgz#1950b9be441474a67f852811c1d4ec955885d2c8"
-  integrity sha512-i69WkEU5ZAL8mrmdmVviWwU+DN+IUF8f4sSJThoJ3z5A7Nn5iuO5ROX3Boye0u+uYQLOSfgFl7SuFZCjlAVbQA==
+p-retry@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-5.1.2.tgz#c16eaee4f2016f9161d12da40d3b8b0f2e3c1b76"
+  integrity sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==
   dependencies:
     "@types/retry" "0.12.1"
     retry "^0.13.1"
@@ -1308,10 +1170,10 @@ postcss@8.4.14:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-protobufjs@^6.11.2:
-  version "6.11.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
-  integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==
+protobufjs@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.1.2.tgz#a0cf6aeaf82f5625bffcf5a38b7cd2a7de05890c"
+  integrity sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -1323,14 +1185,13 @@ protobufjs@^6.11.2:
     "@protobufjs/path" "^1.1.2"
     "@protobufjs/pool" "^1.1.0"
     "@protobufjs/utf8" "^1.1.0"
-    "@types/long" "^4.0.1"
     "@types/node" ">=13.7.0"
-    long "^4.0.0"
+    long "^5.0.0"
 
 punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
+  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
 
 rabin-rs@^2.1.0:
   version "2.1.0"
@@ -1398,9 +1259,9 @@ run-async@^2.4.0:
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
 rxjs@^7.5.7:
-  version "7.5.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
-  integrity sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
+  integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
   dependencies:
     tslib "^2.1.0"
 
@@ -1442,16 +1303,6 @@ source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
-
-streaming-iterables@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/streaming-iterables/-/streaming-iterables-7.1.0.tgz#9db34b245f7057bf88d855e82ffbc1832a2fd143"
-  integrity sha512-t2KmiLVhqafTRqGefD98s5XAMskfkfprr/BTzPIZz0kWB23iyR7XUkY03yjUf4aZpAuuV2/2SUOVri3LgKuOKw==
-
-streamsearch@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
-  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -1528,24 +1379,17 @@ tslib@^2.1.0, tslib@^2.4.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
-type-fest@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.1.0.tgz#157b74044d9c27fd796b9c6aa46eae6658b1e9b8"
-  integrity sha512-StmrZmK3eD9mDF9Vt7UhqthrDSk66O9iYl5t5a0TSoVkHjl0XZx/xuc/BRz4urAXXGHOY5OLsE0RdJFIApSFmw==
+type-fest@^3.0.0, type-fest@^3.3.0:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.5.2.tgz#16ff97c5dc1fd6bd6d50ef3c6ba92cc9c1add859"
+  integrity sha512-Ph7S4EhXzWy0sbljEuZo0tTNoLl+K2tPauGrQpcwUWrOVneLePTuhVzcuzVJJ6RU5DsNwQZka+8YtkXXU4z9cA==
 
-uint8arrays@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-3.1.1.tgz#2d8762acce159ccd9936057572dade9459f65ae0"
-  integrity sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==
+uint8arrays@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-4.0.3.tgz#43109c03c4c10d312e7f2e9f4d53e5cd2398c7fd"
+  integrity sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==
   dependencies:
-    multiformats "^9.4.2"
-
-undici@^5.10.0:
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.12.0.tgz#c758ffa704fbcd40d506e4948860ccaf4099f531"
-  integrity sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==
-  dependencies:
-    busboy "^1.6.0"
+    multiformats "^11.0.0"
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -1564,17 +1408,6 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-util@^0.12.3:
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
-  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
-  dependencies:
-    inherits "^2.0.3"
-    is-arguments "^1.0.4"
-    is-generator-function "^1.0.7"
-    is-typed-array "^1.1.3"
-    which-typed-array "^1.1.2"
-
 varint@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/varint/-/varint-6.0.0.tgz#9881eb0ce8feaea6512439d19ddf84bf551661d0"
@@ -1587,31 +1420,10 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web-encoding@1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.1.5.tgz#fc810cf7667364a6335c939913f5051d3e0c4864"
-  integrity sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==
-  dependencies:
-    util "^0.12.3"
-  optionalDependencies:
-    "@zxing/text-encoding" "0.9.0"
-
 web-streams-polyfill@^3.1.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
   integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
-
-which-typed-array@^1.1.2:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.9.tgz#307cf898025848cf995e795e8423c7f337efbde6"
-  integrity sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==
-  dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    for-each "^0.3.3"
-    gopd "^1.0.1"
-    has-tostringtag "^1.0.0"
-    is-typed-array "^1.1.10"
 
 wrap-ansi@^8.0.1:
   version "8.0.1"
@@ -1622,17 +1434,17 @@ wrap-ansi@^8.0.1:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
-ws@^8.8.1:
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.10.0.tgz#00a28c09dfb76eae4eb45c3b565f771d6951aa51"
-  integrity sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==
+ws@^8.11.0:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.0.tgz#485074cc392689da78e1828a9ff23585e06cddd8"
+  integrity sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==
 
 yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-zod@^3.19.1:
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.19.1.tgz#112f074a97b50bfc4772d4ad1576814bd8ac4473"
-  integrity sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==
+zod@^3.20.2:
+  version "3.20.2"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.20.2.tgz#068606642c8f51b3333981f91c0a8ab37dfc2807"
+  integrity sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==


### PR DESCRIPTION
This updates things to use the new APIs (e.g. `useKeyring` instead of `useAuth`, etc).

This gets us halfway to done on https://github.com/web3-storage/web3.storage/issues/2189, the other half being to update the code snippets in the post & link to this fork instead of the original.
